### PR TITLE
Remove "docs" subdir for website routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ web:  pythonanalysis
 	#git add .
 	#git commit -m "added content"
 	#git push
-	python3 -m http.server
+	python3 -m http.server --directory docs/
 	# python3 -mwebbrowser http://127.0.0.1:8000/report.pdf

--- a/docs/projects/HISEAShardware/index.html
+++ b/docs/projects/HISEAShardware/index.html
@@ -15,10 +15,10 @@
           <!-- we have used list tag that is ul
                to list the items-->
           <ul class="nav-list">
-              <li><a href="/docs/index.html">J.E. Snyder</a></li>
-              <li><a href="/docs/about/">About</a></li>
-              <li><a href="/docs/projects/">Projects</a></li>
-              <li><a href="/docs/cv/">CV</a></li>
+              <li><a href="/index.html">J.E. Snyder</a></li>
+              <li><a href="/about/">About</a></li>
+              <li><a href="/projects/">Projects</a></li>
+              <li><a href="/cv/">CV</a></li>
           </ul>
           <!-- we have used rightnav in order to design
                the seachbar properly by using CSS-->

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -170,7 +170,7 @@
   </div>
   <div style="width:50%; margin-left: 325px;">
     <p> <b>
-    <a href="/docs/projects/microgreen/">Microgreen Farming</a>
+    <a href="/projects/microgreen/">Microgreen Farming</a>
   </b><br><i>
     The Hawaii Space Exploration Analog and Simulation (HISEAS) 2020
   </i><br>
@@ -187,7 +187,7 @@
   </div>
   <div id="text4" style="width:50%; margin-left: 325px;">
     <p> <b>
-    <a href="/docs/projects/microgreen/">Microgreen Farming</a>
+    <a href="/projects/microgreen/">Microgreen Farming</a>
   </b><br><i>
     The Hawaii Space Exploration Analog and Simulation (HISEAS) 2020
   </i><br>

--- a/docs/projects/microgreen/index.html
+++ b/docs/projects/microgreen/index.html
@@ -15,10 +15,10 @@
           <!-- we have used list tag that is ul
                to list the items-->
           <ul class="nav-list">
-              <li><a href="/docs/index.html">J.E. Snyder</a></li>
-              <li><a href="/docs/about/">About</a></li>
-              <li><a href="/docs/projects/">Projects</a></li>
-              <li><a href="/docs/cv/">CV</a></li>
+              <li><a href="/index.html">J.E. Snyder</a></li>
+              <li><a href="/about/">About</a></li>
+              <li><a href="/projects/">Projects</a></li>
+              <li><a href="/cv/">CV</a></li>
           </ul>
           <!-- we have used rightnav in order to design
                the seachbar properly by using CSS-->

--- a/docs/projects/slimeComputer/index.html
+++ b/docs/projects/slimeComputer/index.html
@@ -15,10 +15,10 @@
           <!-- we have used list tag that is ul
                to list the items-->
           <ul class="nav-list">
-              <li><a href="/docs/index.html">J.E. Snyder</a></li>
-              <li><a href="/docs/about/">About</a></li>
-              <li><a href="/docs/projects/">Projects</a></li>
-              <li><a href="/docs/cv/">CV</a></li>
+              <li><a href="/index.html">J.E. Snyder</a></li>
+              <li><a href="/about/">About</a></li>
+              <li><a href="/projects/">Projects</a></li>
+              <li><a href="/cv/">CV</a></li>
           </ul>
           <!-- we have used rightnav in order to design
                the seachbar properly by using CSS-->


### PR DESCRIPTION
Previously all website content was housed under /docs/, e.g. "http://localhost:8000/docs" was the homepage. Let's instead treat the contents of the "docs" directory as the root of the website itself. Modified the dev web server command, and the hardcoded hrefs in the HTML files, to accommodate.

To test this PR:

1. Check out the code locally
2. Run `make web` and confirm no errors
3. Browse locally to `http://localhost:8000` (not `http://localhost:8000/docs`!), confirm page loads
4. Click through navigation throughout site, confirm no 404s anywhere.